### PR TITLE
Fix/forwarded headers https redirect

### DIFF
--- a/backend/KPlista.Api/Program.cs
+++ b/backend/KPlista.Api/Program.cs
@@ -127,11 +127,13 @@ var app = builder.Build();
 // Apply forwarded headers BEFORE generating security headers or auth redirects
 app.UseForwardedHeaders(); // Processes X-Forwarded-Proto/Host (and only first value)
 // Optional diagnostic logging of forwarded headers (enable via Logging:DebugForwardedHeaders=true)
+// Note: This logs RemoteIpAddress for debugging proxy/forwarding issues
 if (app.Configuration.GetValue<bool>("Logging:DebugForwardedHeaders"))
 {
+    var loggerFactory = app.Services.GetRequiredService<ILoggerFactory>();
+    var log = loggerFactory.CreateLogger<Program>();
     app.Use(async (ctx, next) =>
     {
-        var log = ctx.RequestServices.GetRequiredService<ILogger<Program>>();
         var remoteIp = ctx.Connection.RemoteIpAddress?.ToString();
         var xfp = ctx.Request.Headers["X-Forwarded-Proto"].ToString();
         var xfh = ctx.Request.Headers["X-Forwarded-Host"].ToString();

--- a/backend/KPlista.Api/appsettings.Development.json
+++ b/backend/KPlista.Api/appsettings.Development.json
@@ -4,7 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Information"
-    }
+    },
+    "DebugForwardedHeaders": false
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Database=kplista;Username=postgres;Password=postgres"

--- a/backend/KPlista.Api/appsettings.json
+++ b/backend/KPlista.Api/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
-    }
+    },
+    "DebugForwardedHeaders": false
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {


### PR DESCRIPTION
This pull request adds support for processing forwarded headers in the `KPlista.Api` backend to ensure correct scheme and host detection when running behind a reverse proxy or load balancer (e.g., for HTTPS termination). It also introduces configuration for trusted proxy IPs and optional diagnostic logging for easier debugging of forwarded header issues.

**Forwarded headers and reverse proxy support:**

* Added configuration for `ForwardedHeadersOptions` to process only `X-Forwarded-Proto` and `X-Forwarded-Host` headers, with a limit on the number of forwarded entries and support for specifying a trusted proxy IP via configuration (`ReverseProxy:TrustedProxyIp`). This helps prevent header spoofing and ensures correct URL reconstruction behind a proxy.
* Registered the `UseForwardedHeaders` middleware early in the pipeline to process forwarded headers before security headers or authentication redirects, ensuring accurate scheme and host information throughout the app.

**Diagnostics and logging:**

* Added optional diagnostic logging for forwarded headers, controlled by the `Logging:DebugForwardedHeaders` configuration key, to assist with troubleshooting proxy-related issues.

**Dependency updates:**

* Imported the `Microsoft.AspNetCore.HttpOverrides` namespace to enable forwarded headers functionality.