### PR TITLE
chore(logging): proxy diagnostics env + post-forwarded logging

### DIFF
--- a/backend/KPlista.Api/Program.cs
+++ b/backend/KPlista.Api/Program.cs
@@ -148,6 +148,16 @@ if (builder.Configuration.GetValue<bool>("Logging:DebugForwardedHeaders"))
 }
 // Apply forwarded headers BEFORE generating security headers or auth redirects
 app.UseForwardedHeaders(); // Processes X-Forwarded-Proto/Host (and only first value)
+// Post-processing diagnostics (after applying forwarded headers) if enabled
+if (builder.Configuration.GetValue<bool>("Logging:DebugForwardedHeaders"))
+{
+    app.Use(async (ctx, next) =>
+    {
+        Log.Information("ForwardedHeadersPost RemoteIp={RemoteIp} EffectiveScheme={Scheme} EffectiveHost={Host}",
+            ctx.Connection.RemoteIpAddress?.ToString(), ctx.Request.Scheme, ctx.Request.Host.ToString());
+        await next();
+    });
+}
 app.Use(async (context, next) =>
 {
     var headers = context.Response.Headers;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       Jwt__Secret: "${JWT_SECRET:-your-secret-key-min-32-characters-long-for-security-please-change-in-production}"
       Jwt__Issuer: "${JWT_ISSUER:-koplista-api}"
       Jwt__Audience: "${JWT_AUDIENCE:-koplista-app}"
+      # Enable forwarded headers diagnostic logging (raw + post-processed)
+      Logging__DebugForwardedHeaders: "true"
     ports:
       - "80:8080"
     depends_on:


### PR DESCRIPTION
Adds:\n- Logging__DebugForwardedHeaders=true in docker-compose (raw + post processed)\n- Post-forwarded logging middleware after app.UseForwardedHeaders()\n\nEnable diagnostics by keeping env var true; set to false in production to reduce noise.