### PR TITLE
Add controller challenge logging

### DIFF
--- a/backend/KPlista.Api/Controllers/AuthController.cs
+++ b/backend/KPlista.Api/Controllers/AuthController.cs
@@ -186,6 +186,7 @@ public class AuthController : ControllerBase
     [HttpGet("google")]
     public IActionResult LoginGoogle()
     {
+        _logger.LogInformation("AuthController: Initiating Google OAuth challenge");
         // Explicit callback path defined in Program.cs (options.CallbackPath)
         // Challenge without custom RedirectUri; callback endpoint handles final redirect to frontend
         return Challenge(new AuthenticationProperties(), "Google");
@@ -255,6 +256,7 @@ public class AuthController : ControllerBase
     [HttpGet("facebook")]
     public IActionResult LoginFacebook()
     {
+        _logger.LogInformation("AuthController: Initiating Facebook OAuth challenge");
         // Explicit callback path defined in Program.cs (options.CallbackPath)
         // Challenge without custom RedirectUri; callback endpoint handles final redirect to frontend
         return Challenge(new AuthenticationProperties(), "Facebook");


### PR DESCRIPTION
Adds explicit logging in AuthController for initiating Google/Facebook OAuth challenges to aid in diagnosing missing redirect behavior.