### PR TITLE
Remove OnRedirectToAuthorizationEndpoint handlers that block OAuth redirect

### DIFF
--- a/backend/KPlista.Api/Program.cs
+++ b/backend/KPlista.Api/Program.cs
@@ -133,11 +133,6 @@ builder.Services.AddAuthentication(options =>
     options.CallbackPath = "/api/auth/google-callback"; // our controller will issue JWT
     options.Events = new Microsoft.AspNetCore.Authentication.OAuth.OAuthEvents
     {
-        OnRedirectToAuthorizationEndpoint = context =>
-        {
-            Log.Information("OAuth Google: Redirecting to provider {RedirectUri}", context.RedirectUri);
-            return Task.CompletedTask;
-        },
         OnCreatingTicket = context =>
         {
             var email = context.Principal?.FindFirst(ClaimTypes.Email)?.Value ?? "(no email)";
@@ -162,11 +157,6 @@ builder.Services.AddAuthentication(options =>
     options.CallbackPath = "/api/auth/facebook-callback";
     options.Events = new Microsoft.AspNetCore.Authentication.OAuth.OAuthEvents
     {
-        OnRedirectToAuthorizationEndpoint = context =>
-        {
-            Log.Information("OAuth Facebook: Redirecting to provider {RedirectUri}", context.RedirectUri);
-            return Task.CompletedTask;
-        },
         OnCreatingTicket = context =>
         {
             var email = context.Principal?.FindFirst(ClaimTypes.Email)?.Value ?? "(no email)";


### PR DESCRIPTION
PR #43 added diagnostic handlers including OnRedirectToAuthorizationEndpoint which inadvertently blocks the OAuth redirect. These handlers logged but did not call context.Response.Redirect, preventing users from reaching the OAuth provider. Removing these handlers restores redirect functionality while keeping OnCreatingTicket and OnRemoteFailure diagnostics.