### PR TITLE
fix: remove property target from Range attributes on record DTOs

### DIFF
--- a/backend/KPlista.Api/DTOs/GroceryItemDtos.cs
+++ b/backend/KPlista.Api/DTOs/GroceryItemDtos.cs
@@ -20,7 +20,7 @@ public record GroceryItemDto(
 public record CreateGroceryItemDto(
     string Name,
     string? Description,
-    [property: Range(1, int.MaxValue)] int Quantity,
+    [Range(1, int.MaxValue)] int Quantity,
     string? Unit,
     Guid? GroupId
 );
@@ -28,7 +28,7 @@ public record CreateGroceryItemDto(
 public record UpdateGroceryItemDto(
     string Name,
     string? Description,
-    [property: Range(1, int.MaxValue)] int Quantity,
+    [Range(1, int.MaxValue)] int Quantity,
     string? Unit,
     Guid? GroupId
 );


### PR DESCRIPTION
## Problem
Adding or updating grocery items returns a 500 error with System.InvalidOperationException: Record type 'KPlista.Api.DTOs.CreateGroceryItemDto' has validation metadata defined on property 'Quantity'.

## Root Cause
The [property: Range(1, int.MaxValue)] attribute target on record positional parameters causes an InvalidOperationException in ASP.NET Core. Records should use parameter-targeted attributes (no property: prefix).

## Fix
Removed the property: target from Range attributes on CreateGroceryItemDto and UpdateGroceryItemDto.

## Files Changed
- ackend/KPlista.Api/DTOs/GroceryItemDtos.cs
